### PR TITLE
Improved performance of BindVar()

### DIFF
--- a/bindvar.go
+++ b/bindvar.go
@@ -1,6 +1,8 @@
 package sqlf
 
-import "fmt"
+import (
+	"strconv"
+)
 
 // BindVar is used to take a format string and convert it into query
 // string that a gorp.SqlExecutor or sql.Query can use. It is the
@@ -39,19 +41,19 @@ type postgresBindVar struct{}
 
 // Returns "$(i+1)"
 func (d postgresBindVar) BindVar(i int) string {
-	return fmt.Sprintf("$%d", i+1)
+	return "$" + strconv.Itoa(i+1)
 }
 
 type sqlServerBindVar struct{}
 
 // Returns "@p(i+1)"
 func (d sqlServerBindVar) BindVar(i int) string {
-	return fmt.Sprintf("@p%d", i+1)
+	return "@p" + strconv.Itoa(i+1)
 }
 
 type oracleBindVar struct{}
 
 // Returns ":(i+1)"
 func (d oracleBindVar) BindVar(i int) string {
-	return fmt.Sprintf(":%d", i+1)
+	return ":" + strconv.Itoa(i+1)
 }

--- a/bindvar_test.go
+++ b/bindvar_test.go
@@ -1,0 +1,31 @@
+package sqlf_test
+
+import (
+	"testing"
+
+	"github.com/keegancsmith/sqlf"
+)
+
+func BenchmarkPostgresBindVar(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = sqlf.PostgresBindVar.BindVar(i)
+	}
+}
+
+func BenchmarkOracleBindVar(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = sqlf.OracleBindVar.BindVar(i)
+	}
+}
+
+func BenchmarkSQLServerBindVar(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = sqlf.SQLServerBindVar.BindVar(i)
+	}
+}
+
+func BenchmarkSimpleBindVar(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = sqlf.SimpleBindVar.BindVar(i)
+	}
+}

--- a/sqlf.go
+++ b/sqlf.go
@@ -2,8 +2,8 @@
 //
 // A simple example:
 //
-//   q := sqlf.Sprintf("SELECT * FROM users WHERE country = %s AND age > %d", "US", 27);
-//   rows, err := db.Query(q.Query(sqlf.SimpleBindVar), q.Args()...) // db is a database/sql.DB
+//	q := sqlf.Sprintf("SELECT * FROM users WHERE country = %s AND age > %d", "US", 27);
+//	rows, err := db.Query(q.Query(sqlf.SimpleBindVar), q.Args()...) // db is a database/sql.DB
 //
 // sqlf.Sprintf does not return a string. It returns *sqlf.Query which has
 // methods for a parameterized SQL query and arguments. You then pass that to
@@ -47,7 +47,7 @@ func Sprintf(format string, args ...interface{}) *Query {
 	// according to fmt format specifier semantics), but it would also go through fmt.Sprintf
 	// again at Query.Query(binder) time - so we need to make sure `%%` remains as `%%` in our
 	// format string. See the literal_percent_operator test.
-	format = strings.Replace(format, "%%", "%%%%", -1)
+	format = strings.ReplaceAll(format, "%%", "%%%%")
 	return &Query{
 		fmt:  fmt.Sprintf(format, f...),
 		args: a,

--- a/sqlf_test.go
+++ b/sqlf_test.go
@@ -15,30 +15,42 @@ func TestSprintf(t *testing.T) {
 		WantArgs []interface{}
 	}{
 		"simple_substitute": {
-			"SELECT * FROM test_table WHERE a = %s AND b = %d", []interface{}{"foo", 1},
-			"SELECT * FROM test_table WHERE a = $1 AND b = $2", []interface{}{"foo", 1},
+			"SELECT * FROM test_table WHERE a = %s AND b = %d",
+			[]interface{}{"foo", 1},
+			"SELECT * FROM test_table WHERE a = $1 AND b = $2",
+			[]interface{}{"foo", 1},
 		},
 
 		"simple_embedded": {
-			"SELECT * FROM test_table WHERE a = (%s)", []interface{}{sqlf.Sprintf("SELECT b FROM b_table WHERE x = %d", 1)},
-			"SELECT * FROM test_table WHERE a = (SELECT b FROM b_table WHERE x = $1)", []interface{}{1},
+			"SELECT * FROM test_table WHERE a = (%s)",
+			[]interface{}{sqlf.Sprintf("SELECT b FROM b_table WHERE x = %d", 1)},
+			"SELECT * FROM test_table WHERE a = (SELECT b FROM b_table WHERE x = $1)",
+			[]interface{}{1},
 		},
 
 		"embedded": {
-			"SELECT * FROM test_table WHERE a = %s AND c = (%s) AND d = %s", []interface{}{"foo", sqlf.Sprintf("SELECT b FROM b_table WHERE x = %d", 1), "bar"},
-			"SELECT * FROM test_table WHERE a = $1 AND c = (SELECT b FROM b_table WHERE x = $2) AND d = $3", []interface{}{"foo", 1, "bar"},
+			"SELECT * FROM test_table WHERE a = %s AND c = (%s) AND d = %s",
+			[]interface{}{"foo", sqlf.Sprintf("SELECT b FROM b_table WHERE x = %d", 1), "bar"},
+			"SELECT * FROM test_table WHERE a = $1 AND c = (SELECT b FROM b_table WHERE x = $2) AND d = $3",
+			[]interface{}{"foo", 1, "bar"},
 		},
 
 		"embedded_embedded": {
 			"SELECT * FROM test_table WHERE a = %s AND c = (%s) AND d = %s",
-			[]interface{}{"foo", sqlf.Sprintf("SELECT b FROM b_table WHERE x = %d AND y = (%s)", 1, sqlf.Sprintf("SELECT %s", "baz")), "bar"},
+			[]interface{}{
+				"foo",
+				sqlf.Sprintf("SELECT b FROM b_table WHERE x = %d AND y = (%s)", 1, sqlf.Sprintf("SELECT %s", "baz")),
+				"bar",
+			},
 			"SELECT * FROM test_table WHERE a = $1 AND c = (SELECT b FROM b_table WHERE x = $2 AND y = (SELECT $3)) AND d = $4",
 			[]interface{}{"foo", 1, "baz", "bar"},
 		},
 
 		"literal_percent_operator": {
-			"SELECT * FROM test_table WHERE a <<%% %s AND b = %d", []interface{}{"foo", 1},
-			"SELECT * FROM test_table WHERE a <<% $1 AND b = $2", []interface{}{"foo", 1},
+			"SELECT * FROM test_table WHERE a <<%% %s AND b = %d",
+			[]interface{}{"foo", 1},
+			"SELECT * FROM test_table WHERE a <<% $1 AND b = $2",
+			[]interface{}{"foo", 1},
 		},
 	}
 	for tn, tc := range cases {
@@ -49,5 +61,11 @@ func TestSprintf(t *testing.T) {
 		if got := q.Args(); !reflect.DeepEqual(got, tc.WantArgs) {
 			t.Errorf("%s: expected args: %q, got: %q", tn, tc.WantArgs, got)
 		}
+	}
+}
+
+func BenchmarkSprintf(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = sqlf.Sprintf("SELECT * FROM test_table WHERE a = %s AND b = %d", "foo", 1).Query(sqlf.PostgresBindVar)
 	}
 }


### PR DESCRIPTION
A simple improvement to the BindVar functions. 

```
benchstat original.bench strconv.bench                                                                                                                                                                                                              k1ng@rog-beast
goos: linux
goarch: amd64
pkg: github.com/keegancsmith/sqlf
cpu: AMD Ryzen 9 5950X 16-Core Processor            
                    │ original.bench │             strconv.bench             │
                    │     sec/op     │    sec/op      vs base                │
PostgresBindVar-32     121.15n ± 17%    47.91n ± 10%  -60.46% (p=0.000 n=10)
OracleBindVar-32       118.60n ± 11%    44.23n ±  5%  -62.71% (p=0.000 n=10)
SQLServerBindVar-32    108.20n ±  7%    45.90n ± 12%  -57.58% (p=0.000 n=10)
SimpleBindVar-32       0.2366n ±  4%   0.2572n ± 10%   +8.75% (p=0.011 n=10)
Sprintf-32             1094.5n ±  8%    930.5n ± 19%  -14.98% (p=0.015 n=10)

                    │ original.bench │            strconv.bench             │
                    │      B/op      │    B/op     vs base                  │
PostgresBindVar-32     17.000 ± 6%     7.000 ± 0%  -58.82% (p=0.000 n=10)
OracleBindVar-32       16.000 ± 0%     7.000 ± 0%  -56.25% (p=0.000 n=10)
SQLServerBindVar-32    23.000 ± 0%     7.000 ± 0%  -69.57% (p=0.000 n=10)
SimpleBindVar-32        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sprintf-32              308.0 ± 0%     308.0 ± 0%        ~ (p=1.000 n=10) ¹

                    │ original.bench │              strconv.bench              │
                    │   allocs/op    │ allocs/op   vs base                     │
PostgresBindVar-32     1.000 ±  0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
OracleBindVar-32       1.000 ±  0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
SQLServerBindVar-32    2.000 ± 50%     0.000 ± 0%  -100.00% (p=0.000 n=10)
SimpleBindVar-32       0.000 ±  0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sprintf-32             12.00 ±  0%     12.00 ± 0%         ~ (p=1.000 n=10) ¹

```